### PR TITLE
Adjusted to new public plugin.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+lint:
+	docker-compose run --rm lint

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ steps:
   - label: "Single Deployment Step"
     key: "deployment:${ENVIRONMENT}:${REGION}:single-deployment-step"
     plugins:
-    - rokt/tag-release#v1.0.0:
-        mark_pending: true
+    - ROKT/tag-release#v1.0.3-beta:
         mark_completed: true
 ```
 
@@ -41,12 +40,13 @@ steps:
   - label: "First Deployment Step"
     key: "deployment:${ENVIRONMENT}:${REGION}:first-deployment-step"
     plugins:
-    - rokt/tag-release#v1.0.0:
+    - ROKT/tag-release#v1.0.3-beta:
         mark_pending: true
 
   - label: "Final Deployment Step"
     key: "deployment:${ENVIRONMENT}:${REGION}:last-deployment-step"
-    - rokt/tag-release#v1.0.0:
+    plugins:
+    - ROKT/tag-release#v1.0.3-beta:
         mark_completed: true
 ```
 
@@ -61,21 +61,21 @@ steps:
   - label: "Deploy Service One"
     key: "deployment:${ENVIRONMENT}:${REGION}:deploy-service-one"
     plugins:
-    - rokt/tag-release#v1.0.0:
+    - ROKT/tag-release#v1.0.3-beta:
         mark_pending: true
-        mark_completed: true
         tag_identifier: service-one
 
   - label: "Begin Deployment of Service Two"
     key: "deployment:${ENVIRONMENT}:${REGION}:begin-deploy-service-two"
     plugins:
-    - rokt/tag-release#v1.0.0:
+    - ROKT/tag-release#v1.0.3-beta:
         mark_pending: true
         tag_identifier: service-two
 
   - label: "Complete Deployment of Service Two"
     key: "deployment:${ENVIRONMENT}:${REGION}:complete-deployment-service-two"
-    - rokt/tag-release#v1.0.0:
+    plugins:
+    - ROKT/tag-release#v1.0.3-beta:
         mark_completed: true
         tag_identifier: service-two
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  lint:
+    image: buildkite/plugin-linter
+    command: ['--id', 'ROKT/tag-release']
+    volumes:
+      - ".:/plugin:ro"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -3,7 +3,7 @@ set -eo pipefail
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 
-if [ "${BUILDKITE_PLUGIN_BUILDKITE_TAG_RELEASE_MARK_COMPLETED}" == "true" ]
+if [ "${BUILDKITE_PLUGIN_TAG_RELEASE_MARK_COMPLETED}" == "true" ]
 then
-  $basedir/lib/tag-release.sh "current" "pending" "previous" "${BUILDKITE_PLUGIN_BUILDKITE_TAG_RELEASE_TAG_IDENTIFIER}"
+  $basedir/lib/tag-release.sh "current" "pending" "previous" "${BUILDKITE_PLUGIN_TAG_RELEASE_TAG_IDENTIFIER}"
 fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -3,7 +3,7 @@ set -eo pipefail
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 
-if [ "${BUILDKITE_PLUGIN_BUILDKITE_TAG_RELEASE_MARK_PENDING}" == "true" ]
+if [ "${BUILDKITE_PLUGIN_TAG_RELEASE_MARK_PENDING}" == "true" ]
 then
-  $basedir/lib/tag-release.sh "pending" "" "" "${BUILDKITE_PLUGIN_BUILDKITE_TAG_RELEASE_TAG_IDENTIFIER}"
+  $basedir/lib/tag-release.sh "pending" "" "" "${BUILDKITE_PLUGIN_TAG_RELEASE_TAG_IDENTIFIER}"
 fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,6 @@
-name: "buildkite_tag_release"
+name: Tag Release
 description: Tag commits with release tag when deploying
+author: https://github.com/ROKT
 public: true
 requirements:
   - bash
@@ -12,9 +13,9 @@ configuration:
       type: boolean # Should we mark the commit as current / previous
     tag_identifier:
       type: string # An identifier to include in the tag to distinguish deployment of different services within the same repository
-    oneOf:
-    - required:
-      - mark_pending
-    - required:
-      - mark_completed
+  oneOf:
+  - required:
+    - mark_pending
+  - required:
+    - mark_completed
   additionalProperties: false


### PR DESCRIPTION
### Background ###

The plugin has previously been accessed via ssh link. To move towards accessing it via `ROKT/tag-release`, we must accommodate several formatting changes.

### What Has Changed: ###

Added plugin linter ~ compose+make.

Changed hooks from using `BUILDKITE_PLUGIN_MY_PLUGIN_GIT_PATTERN` from the previous iteration referenced as a plugin via ssh to the new format of `BUILDKITE_PLUGIN_<PLUGIN_NAME>_<CONFIGURATION_PROPERTY>` for "PLUGIN_NAME" as a publicly accessible plugin. 

Removed indenting for the `oneOf` requirement in the plugin and updated the examples in the readme.

### How Has This Been Tested? ###

Using the new linter check to verify plugin integrity.

### Notes

Updates actioned from the current state of recommendations on https://buildkite.com/docs/plugins/writing and from using the new linting checker

### Checklist: ###

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.