### PR TITLE
Allow both pending and complete.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ steps:
     key: "deployment:${ENVIRONMENT}:${REGION}:single-deployment-step"
     plugins:
     - ROKT/tag-release#v1.0.3-beta:
+        mark_pending: true
         mark_completed: true
 ```
 
@@ -63,6 +64,7 @@ steps:
     plugins:
     - ROKT/tag-release#v1.0.3-beta:
         mark_pending: true
+        mark_completed: true
         tag_identifier: service-one
 
   - label: "Begin Deployment of Service Two"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ steps:
   - label: "Single Deployment Step"
     key: "deployment:${ENVIRONMENT}:${REGION}:single-deployment-step"
     plugins:
-    - ROKT/tag-release#v1.0.3-beta:
+    - ROKT/tag-release#v1.1.0:
         mark_pending: true
         mark_completed: true
 ```
@@ -41,13 +41,13 @@ steps:
   - label: "First Deployment Step"
     key: "deployment:${ENVIRONMENT}:${REGION}:first-deployment-step"
     plugins:
-    - ROKT/tag-release#v1.0.3-beta:
+    - ROKT/tag-release#v1.1.0:
         mark_pending: true
 
   - label: "Final Deployment Step"
     key: "deployment:${ENVIRONMENT}:${REGION}:last-deployment-step"
     plugins:
-    - ROKT/tag-release#v1.0.3-beta:
+    - ROKT/tag-release#v1.1.0:
         mark_completed: true
 ```
 
@@ -62,7 +62,7 @@ steps:
   - label: "Deploy Service One"
     key: "deployment:${ENVIRONMENT}:${REGION}:deploy-service-one"
     plugins:
-    - ROKT/tag-release#v1.0.3-beta:
+    - ROKT/tag-release#v1.1.0:
         mark_pending: true
         mark_completed: true
         tag_identifier: service-one
@@ -70,14 +70,14 @@ steps:
   - label: "Begin Deployment of Service Two"
     key: "deployment:${ENVIRONMENT}:${REGION}:begin-deploy-service-two"
     plugins:
-    - ROKT/tag-release#v1.0.3-beta:
+    - ROKT/tag-release#v1.1.0:
         mark_pending: true
         tag_identifier: service-two
 
   - label: "Complete Deployment of Service Two"
     key: "deployment:${ENVIRONMENT}:${REGION}:complete-deployment-service-two"
     plugins:
-    - ROKT/tag-release#v1.0.3-beta:
+    - ROKT/tag-release#v1.1.0:
         mark_completed: true
         tag_identifier: service-two
 ```

--- a/plugin.yml
+++ b/plugin.yml
@@ -13,7 +13,7 @@ configuration:
       type: boolean # Should we mark the commit as current / previous
     tag_identifier:
       type: string # An identifier to include in the tag to distinguish deployment of different services within the same repository
-  oneOf:
+  anyOf:
   - required:
     - mark_pending
   - required:


### PR DESCRIPTION
### Background ###

Both the mark_pending and mark_completed flags should be allowed simultaneously. Currently, _at least one_ **but not both** is allowed. It is intended that _either_ one _or_ **both** _but not_ neither are allowed. 

### What Has Changed: ###

Replaced `oneOf` condition with `anyOf` condition.

### How Has This Been Tested? ###

`make lint`